### PR TITLE
branch without auto locate feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,10 @@
 
           // AUTO LOCATE FEATURE 
           
-          // To Auto-Locate Yourself And create a radius marker. 
-          function onLocationFound(e) {
-            var radius = e.accuracy / 2;
+          // To Auto-Locate Yourself And create a radius marker.
+	// turn off if not in NY 
+          #function onLocationFound(e) {
+            #var radius = e.accuracy / 2;
       
           //Create pop-up to display location accuracy.  Location is coming from IP location or GPS receiver in mobile device
           L.marker(e.latlng, {icon: loc}).addTo(map)


### PR DESCRIPTION
The auto locate feature is best utilized if you're in New York. I turned it off this branch so you can play around with the map without being forced to auto locate your current location.